### PR TITLE
allow JSONArray as top level object

### DIFF
--- a/src/main/groovy/cz/alenkacz/gradle/jsonvalidator/ValidateJsonTask.groovy
+++ b/src/main/groovy/cz/alenkacz/gradle/jsonvalidator/ValidateJsonTask.groovy
@@ -1,14 +1,16 @@
 package cz.alenkacz.gradle.jsonvalidator
 
 import groovy.io.FileType
+import org.everit.json.schema.ArraySchema
 import org.everit.json.schema.Schema
 import org.everit.json.schema.ValidationException
 import org.everit.json.schema.loader.SchemaLoader
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
-import org.gradle.api.tasks.InputFile
+import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 import org.json.JSONTokener
@@ -50,7 +52,11 @@ class ValidateJsonTask extends DefaultTask {
             List<ValidationError> violations = []
             targetJsonFilesList.each {
                 try {
-                    schema.validate(new JSONObject(new FileInputStream(it).getText()))
+                    if (schema instanceof ArraySchema) {
+                        schema.validate(new JSONArray(new FileInputStream(it).getText()))
+                    } else {
+                        schema.validate(new JSONObject(new FileInputStream(it).getText()))
+                    }
                 } catch (ValidationException e) {
                     violations << new ValidationError(jsonFilePath: it.absolutePath, violations: getViolations(e))
                 } catch (JSONException e) {


### PR DESCRIPTION
Hi @alenkacz,
I really want to use your plugin, but most of my json files have `JSONArray`s as top level object, so the task always fails :disappointed: 

I'm not sure if this is the best approach, though... I also added some tests to validate the change, but it would be great if you could validate it yourself and check if it makes sense :)

Fixes #14
Build output:
```
❯ ./gradlew clean build
:clean
:compileJava UP-TO-DATE
:compileGroovy
:processResources
:classes
:jar
:sourcesJar
:assemble
:createClasspathManifest
:compileTestJava UP-TO-DATE
:compileTestGroovy
:processTestResources UP-TO-DATE
:testClasses
:test
:check
:build

BUILD SUCCESSFUL

Total time: 10.914 secs
```