### PR TITLE
Update README to show 'modern' syntax for gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,20 @@ Provides json validation as a part of your gradle build pipeline.
 
 This plugin implements a custom task type, [ValidateJsonTask](https://github.com/alenkacz/gradle-json-validator/blob/master/src/main/groovy/cz/alenkacz/gradle/jsonvalidator/ValidateJsonTask.groovy). This task expects two properties - *targetJsonFile* and *jsonSchemaFile* (instead of *targetJsonFile* you can use *targetJsonDirectory* and then all files in that directory will be validated). If that directory contains both json and non-json files, the task will fail for non-json files. If you want to validate only files with .json extension use the `onlyWithJsonExtension` property. If you need to validate more jsons as a part of one build, you will have to create as many custom tasks as the number of json schema files (see *validateCustomJson* in the example below).
 
-Usage
-====================
+For the following 'FILL_VERSION_HERE' is [ ![](https://api.bintray.com/packages/alenkacz/maven/gradle-json-validator/images/download.svg) ] as of 2018-10-01 )
 
+Usage 
+====================
+See : [https://plugins.gradle.org/plugin/cz.alenkacz.gradle.jsonvalidator]
+
+Gradle 2.1 or later
+===========
+	plugins {
+	  id "cz.alenkacz.gradle.jsonvalidator" version "FILL_VERSION_HERE"
+	}
+
+Legacy Prior to Gradle 2.1
+==========
 	buildscript {
 		repositories {
 			jcenter()
@@ -19,9 +30,13 @@ Usage
 	}
 
 	apply plugin: 'json-validator'
-	
-    import cz.alenkacz.gradle.jsonvalidator.ValidateJsonTask
-    
+
+
+All Gradle Versions
+=======
+
+   import cz.alenkacz.gradle.jsonvalidator.ValidateJsonTask
+
     task validateCustomJson(type: ValidateJsonTask) {
       targetJsonFile = file("target.json") // only one of targetJsonFile or targetJsonDirectory can be specified 
       targetJsonDirectory = file("directoryWithJsons") // only one of targetJsonFile or targetJsonDirectory can be specified
@@ -34,16 +49,8 @@ JSON schema syntax check
 For some build pipelines it might be useful to be able to check schema files for syntax errors as a part of the build. To make that work, use the following setup and run the task **validateJsonSchema**:
 
 
-	buildscript {
-		repositories {
-			jcenter()
-		}
-		dependencies {
-			classpath 'cz.alenkacz.gradle:json-validator:FILL_VERSION_HERE'
-		}
-	}
+[ Apply plugin as above ]
 
-	apply plugin: 'json-validator'
 	
     jsonSchema {
         schemaFolder = PATH_TO_YOUR_FOLDER_WITH_JSON_SCHEMAS


### PR DESCRIPTION
Reworked gradle syntax to show 'modern'  prefered syntax for Gradle 2.1 or greater (I dont know if this plugin works at all for gradle < 2.1).
Made it a bit more obvious what 'FILL_VERSION_HERE' is