### PR TITLE
#18 Make plugin compatible with Gradle 8

### DIFF
--- a/src/main/groovy/cz/alenkacz/gradle/jsonvalidator/ValidateJsonTask.groovy
+++ b/src/main/groovy/cz/alenkacz/gradle/jsonvalidator/ValidateJsonTask.groovy
@@ -29,6 +29,7 @@ class ValidateJsonTask extends DefaultTask {
     @Input
     @Optional
     Boolean onlyWithJsonExtension
+
     @TaskAction
     def validateJson() {
         // check files exist

--- a/src/main/groovy/cz/alenkacz/gradle/jsonvalidator/ValidateJsonTask.groovy
+++ b/src/main/groovy/cz/alenkacz/gradle/jsonvalidator/ValidateJsonTask.groovy
@@ -26,9 +26,9 @@ class ValidateJsonTask extends DefaultTask {
     @InputDirectory
     @Optional
     File targetJsonDirectory
+    @Input
     @Optional
     Boolean onlyWithJsonExtension
-
     @TaskAction
     def validateJson() {
         // check files exist


### PR DESCRIPTION
Gradle 8 requires to marks properties as input/output to distinguish
what is consumed by task and what is produced. So I've just marked
input property as `@Input`

@alenkacz pls let me know if you can merge it and prepare new version
of plugin :) thanks in advance 👍 